### PR TITLE
Split --git into --git-build and --git-install

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,8 @@ the host system, or `--git-install` to use a git build only for the
 installation root. Note that if using `--git-build` or `--git` additional space
 will be required on the host file system. If using Live mode the tmpfs backing
 the root file system will be automatically resized to a default of 6GiB unless
-either `--no-bigify-root` or `--bigify-root=SIZE` is given.
+either `--no-bigify-root` or `--bigify-root=SIZE` is given. Additionally the VM
+used to run the Live system should have at least 8GiB memory allocated.
 
 Once the build is complete the script configures grub2 and creates a boot entry
 for the Stratis system.

--- a/README.md
+++ b/README.md
@@ -193,7 +193,10 @@ If the `--git` option is given then the script will install build dependencies,
 clone the stratis git repositories and initiate a build for both the host
 system and the installation root. Use `--git-build` to only use a git build on
 the host system, or `--git-install` to use a git build only for the
-installation root.
+installation root. Note that if using `--git-build` or `--git` additional space
+will be required on the host file system. If using Live mode the tmpfs backing
+the root file system will be automatically resized to a default of 6GiB unless
+either `--no-bigify-root` or `--bigify-root=SIZE` is given.
 
 Once the build is complete the script configures grub2 and creates a boot entry
 for the Stratis system.

--- a/README.md
+++ b/README.md
@@ -191,9 +191,9 @@ for stratis root file system support from the distribution repositories.
 
 If the `--git` option is given then the script will install build dependencies,
 clone the stratis git repositories and initiate a build for both the host
-system and the installation root. Use `--git-build` to only use a git build on
-the host system, or `--git-install` to use a git build only for the
-installation root. Note that if using `--git-build` or `--git` additional space
+system and the installation root. Use `--git-host` to only use a git build on
+the host system, or `--git-target` to use a git build only for the target
+installation root. Note that if using `--git-host` or `--git` additional space
 will be required on the host file system. If using Live mode the tmpfs backing
 the root file system will be automatically resized to a default of 6GiB unless
 either `--no-bigify-root` or `--bigify-root=SIZE` is given. Additionally the VM
@@ -300,8 +300,8 @@ options:
   -f, --fs-name FS_NAME
                         Set the file system name
   -g, --git             Perform a build from git master branch instead of packages
-  -B, --git-build       Perform a build from git master branch on the host before creating pools
-  -I, --git-install     Perform a build from git master branch on the target system
+  -B, --git-host        Perform a build from git master branch on the host before creating pools
+  -I, --git-target      Perform a build from git master branch on the target system
   -k, --kickstart KICKSTART
                         Path to a local kickstart file
   -n, --nopartition     Do not partition disks or create Stratis fs

--- a/README.md
+++ b/README.md
@@ -190,7 +190,10 @@ Once the system has been installed the script will install packages required
 for stratis root file system support from the distribution repositories.
 
 If the `--git` option is given then the script will install build dependencies,
-clone the stratis git repositories and initiate a build.
+clone the stratis git repositories and initiate a build for both the host
+system and the installation root. Use `--git-build` to only use a git build on
+the host system, or `--git-install` to use a git build only for the
+installation root.
 
 Once the build is complete the script configures grub2 and creates a boot entry
 for the Stratis system.
@@ -279,29 +282,30 @@ To clean up chroot mounts left by a failed installation use `--cleanup`:
 ------------------------
 
 ```
-usage: stratify.py [-h] [-d TARGET] [-b] [-c] [-e] [--encrypt] [-f FS_NAME] [-g] [-k KICKSTART] [-n] [-p POOL_NAME] [-r] [--repo REPO] [-s SYS_ROOT] [-w]
+usage: stratify.py [-h] [-d TARGET] [-b] [-c] [-e] [--encrypt] [-f FS_NAME] [-g] [-B] [-I] [-k KICKSTART] [-n] [-p POOL_NAME] [-r] [--repo REPO] [-s SYS_ROOT] [-w]
 
 Fedora Stratis Root Install Script
 
 options:
   -h, --help            show this help message and exit
-  -d TARGET, --target TARGET
-                        Specify the device to use
+  -d, --target TARGET   Specify the device to use
   -b, --bios            Assume thesystem is using BIOS firmware
   -c, --cleanup         Clean up and unmount a rescue chroot
   -e, --efi             Assume the system is using EFI firmware
   --encrypt             Encrypt the Stratis pool with a passphrase
-  -f FS_NAME, --fs-name FS_NAME
+  -f, --fs-name FS_NAME
                         Set the file system name
   -g, --git             Perform a build from git master branch instead of packages
-  -k KICKSTART, --kickstart KICKSTART
+  -B, --git-build       Perform a build from git master branch on the host before creating pools
+  -I, --git-install     Perform a build from git master branch on the target system
+  -k, --kickstart KICKSTART
                         Path to a local kickstart file
   -n, --nopartition     Do not partition disks or create Stratis fs
-  -p POOL_NAME, --pool-name POOL_NAME
+  -p, --pool-name POOL_NAME
                         Set the pool name
   -r, --rescue          Rescue a Stratis root installation.
   --repo REPO           Set the repository URL to use for the installation
-  -s SYS_ROOT, --sys-root SYS_ROOT
+  -s, --sys-root SYS_ROOT
                         Set the path to the system root directory
   -w, --wipe            Wipe all devices before initialising
 ```
@@ -331,12 +335,10 @@ Stratis pool when carrying out repeated installations, see comments in
 
 # 10. References & Links
 
-* [Stratis project][4]
-* [stratify.py script][3]
-* [bootstrap script][2]
+* [Stratis project][3]
+* [stratify.py script][2]
 * [example kickstart][1]
 
 [1]: https://raw.githubusercontent.com/bmr-cymru/stratify/main/ks.cfg
-[2]: https://raw.githubusercontent.com/bmr-cymru/stratify/main/bootstrap.sh
-[3]: https://raw.githubusercontent.com/bmr-cymru/stratify/main/stratify.py
-[4]: https://stratis-storage.github.io/
+[2]: https://raw.githubusercontent.com/bmr-cymru/stratify/main/stratify.py
+[3]: https://stratis-storage.github.io/

--- a/stratify.py
+++ b/stratify.py
@@ -3,7 +3,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from subprocess import run as run
+from subprocess import run
 from sys import exit, argv
 from argparse import ArgumentParser
 from os.path import basename, join, exists, isabs

--- a/stratify.py
+++ b/stratify.py
@@ -975,10 +975,10 @@ def main(argv):
                         "system name", default=fs_name)
     parser.add_argument("-g", "--git", action="store_true", help="Perform a "
                         "build from git master branch instead of packages")
-    parser.add_argument("-B", "--git-build", action="store_true",
+    parser.add_argument("-B", "--git-host", action="store_true",
                         help="Perform a build from git master branch on the"
                         " host before creating pools")
-    parser.add_argument("-I", "--git-install", action="store_true",
+    parser.add_argument("-I", "--git-target", action="store_true",
                         help="Perform a build from git master branch on the"
                         " target system")
     parser.add_argument("-k", "--kickstart", type=str, help="Path to a local "
@@ -998,8 +998,8 @@ def main(argv):
     args = parser.parse_args(argv[1:])
 
     if args.git:
-        args.git_build = True
-        args.git_install = True
+        args.git_host = True
+        args.git_target = True
 
     logging.basicConfig(filename="stratify.log", level=logging.DEBUG,
                         filemode="w", format='%(asctime)s %(message)s')
@@ -1056,13 +1056,13 @@ def main(argv):
         fail(1)
 
     host_packages = host_package_deps
-    if not args.git_build:
+    if not args.git_host:
         host_packages += host_package_deps_stratis
 
     # Install dependencies in the live host
     install_deps(host_packages, "host")
 
-    if args.git_build:
+    if args.git_host:
         install_deps(build_deps, "build")
         install_from_git("/")
 
@@ -1083,7 +1083,6 @@ def main(argv):
     fs = args.fs_name
     root = args.sys_root
     rescue = args.rescue
-    git_build = args.git
 
     if args.bios:
         efi = False
@@ -1169,7 +1168,7 @@ def main(argv):
         exit(0)
 
 
-    if git_install:
+    if args.git_target:
         install_deps(build_deps, "build", chroot=root)
         install_from_git(root)
         deploy_build_tree(root)

--- a/stratify.py
+++ b/stratify.py
@@ -1030,13 +1030,13 @@ def main(argv):
         _log_error("No target device given!")
         fail(1)
 
-    # Stop the Stratis daemon if it is running so that we can wipe any
-    # stale data from the target device.
-    stop_stratisd()
-
     if args.wipe:
         # Remove pre-existing stratis pools
         destroy_pools()
+
+    # Stop the Stratis daemon if it is running so that we can wipe any
+    # stale data from the target device.
+    stop_stratisd()
 
     target = args.target
     pool = args.pool_name

--- a/stratify.py
+++ b/stratify.py
@@ -129,7 +129,7 @@ git_deps = [
     ("https://github.com/stratis-storage/stratisd",
      "master", ["make build-all", "make install"]),
     ("https://github.com/stratis-storage/stratis-cli",
-     "master", ["python3 setup.py install"])
+     "master", ["pip install -v ."])
 ]
 
 package_deps = [

--- a/stratify.py
+++ b/stratify.py
@@ -20,6 +20,7 @@ from os import (
 )
 import traceback
 import logging
+import shutil
 import re
 
 _version = "1.1"
@@ -944,6 +945,15 @@ def live_mode():
     return False
 
 
+def deploy_build_tree(root):
+    """Copy the build tree to the target system.
+    """
+    git_basedir = join("/", "root", "git")
+    target_dir = join(root, "root", "git")
+    _log_info("Copying build trees from %s to %s", git_basedir, target_dir)
+    shutil.copytree(git_basedir, target_dir)
+
+
 def main(argv):
     parser = ArgumentParser(prog=basename(argv[0]), description="Fedora "
                             "Stratis Root Install Script")
@@ -1159,11 +1169,12 @@ def main(argv):
         exit(0)
 
 
-    if git_build:
+    if git_install:
         install_deps(build_deps, "build", chroot=root)
         install_from_git(root)
+        deploy_build_tree(root)
     else:
-        install_deps(package_deps, "packages", chroot=root)
+        install_deps(package_deps + package_deps_stratis, "packages", chroot=root)
 
     for unit in enable_units:
         enable_service(root, unit)

--- a/stratify.py
+++ b/stratify.py
@@ -888,6 +888,13 @@ def get_fedora_version():
                 return line.split("=")[1]
 
 
+def disable_selinux():
+    """Disable SELinux to avoid conflict with installation root
+    """
+    setenforce_0_cmd = ["setenforce", "0"]
+    run(setenforce_0_cmd, capture_output=False)
+
+
 def main(argv):
     parser = ArgumentParser(prog=basename(argv[0]), description="Fedora "
                             "Stratis Root Install Script")
@@ -942,6 +949,8 @@ def main(argv):
     _log.addHandler(console_handler)
 
     _log_info("stratify.py %s - %s" % (_version, _date))
+    _log_info("Disabling SELinux to avoid conflict with install root")
+    disable_selinux()
 
     if args.rescue or args.cleanup:
         args.nopartition = True

--- a/stratify.py
+++ b/stratify.py
@@ -23,8 +23,8 @@ import logging
 import shutil
 import re
 
-_version = "1.1"
-_date = "2024-06-28"
+_version = "1.2"
+_date = "2025-03-04"
 
 _debug = False
 

--- a/stratify.py
+++ b/stratify.py
@@ -140,7 +140,8 @@ git_deps = [
     ("https://github.com/stratis-storage/stratisd",
      "master", ["make build-all", "make install"], "DESTDIR=%s"),
     ("https://github.com/stratis-storage/stratis-cli",
-     "master", ["pip install -v ."], "--root=%s")
+    # https://github.com/pypa/pip/issues/3063 :-(
+     "master", ["pip install -I --no-deps -v ."], "--root=%s")
 ]
 
 package_deps = [


### PR DESCRIPTION
Allow the user to separately control whether a git build is used for a) the build host (`--git-build`), or b) the install target (`--git-install`).

If `--git` is given then a git build will be used for both the host and target systems.

N.b.: the final command line options were re-named to `--git-host` and `--git-target` respectively.